### PR TITLE
Disabled rewrite engine in challenge directory

### DIFF
--- a/LE.inc.php
+++ b/LE.inc.php
@@ -236,10 +236,13 @@ class LE {
 		if (false===@file_put_contents($docroot.$this->acme_path.$challenge['token'],$keyAuthorization)){
 			throw new Exception('failed to create challenge file: '.$docroot.$this->acme_path.$challenge['token']);
 		}
+		
+		file_put_contents($docroot.$this->acme_path.'.htaccess', 'RewriteEngine Off');
 	}
 	
 	final protected function remove_challenge($docroot,$challenge){
 		unlink($docroot.$this->acme_path.$challenge['token']);
+		unlink($docroot.$this->acme_path.'.htaccess');
 		rmdir($docroot.$this->acme_path);
 		rmdir($docroot.dirname($this->acme_path));
 	}


### PR DESCRIPTION
After creating the challenge file and directory, CertLE will now create an ".htaccess" file that disables all Apache rewrites in the challenge directory. Many websites redirect naked domains to "www" and HTTP to HTTPS, which prevents LE from verifying domain ownership. Now, no rewrites will happen inside the directory so LE won't get redirected when it verifies ownership.
