### PR TITLE
Added htaccess rule to override blocked access

### DIFF
--- a/LE.inc.php
+++ b/LE.inc.php
@@ -237,7 +237,7 @@ class LE {
 			throw new Exception('failed to create challenge file: '.$docroot.$this->acme_path.$challenge['token']);
 		}
 		
-		file_put_contents($docroot.$this->acme_path.'.htaccess', 'RewriteEngine Off');
+		file_put_contents($docroot.$this->acme_path.'.htaccess', 'RewriteEngine Off'.PHP_EOL.'Allow from all'.PHP_EOL);
 	}
 	
 	final protected function remove_challenge($docroot,$challenge){


### PR DESCRIPTION
Added htaccess rule to override blocked access in the challenge directory, in case the document root htaccess is blocking connections. This might happen if the document root is not intended for the public, but SSL is still needed for other services like email.