### PR TITLE
fix openssl_pkey_export can not produce $pem in somecase.

### DIFF
--- a/CertLE.php
+++ b/CertLE.php
@@ -76,7 +76,7 @@ if (isset($argv[1])){
 			);
 
 			$key=openssl_pkey_new($config);
-			openssl_pkey_export($key,$pem);
+			openssl_pkey_export($key,$pem,null,$config);
 			unlink($fn);
 			echo $pem;		
 		break;


### PR DESCRIPTION
It seems to be under 7.1 version,it can not produce $pem.